### PR TITLE
apps: reenable item control in ActorSheet

### DIFF
--- a/src/module/apps/sheets/ActorSheet.ts
+++ b/src/module/apps/sheets/ActorSheet.ts
@@ -51,8 +51,6 @@ export class ActorSheetStaNg<
   }
 
   protected activateItemControls(html: JQuery<HTMLElement>): void {
-    html.find(".control .edit").on("click", this.onEditItem.bind(this));
-    html.find(".control .delete").on("click", this.onDeleteItem.bind(this));
     html.find(".btn.btn-editors.edit").on("click", this.onEditItem.bind(this));
     html.find(".btn2.btn-editors.delete").on("click", this.onDeleteItem.bind(this));
     html.find(".control.create").on("click", this.onCreateItem.bind(this));
@@ -187,7 +185,7 @@ export class ActorSheetStaNg<
   }
 
   protected getEventItem(event: JQuery.TriggeredEvent): [JQuery<HTMLElement>, ItemStaNg | undefined] {
-    const entry = $(event.currentTarget).parents(".entry");
+    const entry = $(event.currentTarget).parents("li");
     return [entry, this.actor.items.get(entry.data("itemId"))];
   }
 


### PR DESCRIPTION
Since the document structure has changed, the previous mechanism of identifying the item with associated with the control event (edit, delete, ...) did not work anymore. We now need to walk up the parent chain, filtered by tag type instead of class. This is a quick-fix, in the long run, it might be better to encode the item id into a data attribute of the buttons.