### PR TITLE
apps: ignore radio button changes in ActorSheet

### DIFF
--- a/src/module/apps/sheets/ActorSheet.ts
+++ b/src/module/apps/sheets/ActorSheet.ts
@@ -41,6 +41,13 @@ export class ActorSheetStaNg<
     return Promise.resolve([]);
   }
 
+  protected override _onChangeInput(event: JQuery.ChangeEvent<unknown, unknown, unknown, HTMLInputElement>): void | Promise<unknown> {
+    if(event.target.type == "radio") {
+      return;
+    }
+    return super._onChangeInput(event);
+  }
+
   protected get tracks(): string[] {
     return [];
   }


### PR DESCRIPTION
Previously, all input element changes in the ActorSheet did trigger an
update of the associated Actor document. Since the dice-roller
configuration is not part of the Actor document model anymore, the
selection would get lost when such an update was triggered.